### PR TITLE
feat: 腕の先端と敵の当たり判定を実装 (#2)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
@@ -30,6 +32,29 @@ class _GameWrapperState extends State<GameWrapper> {
     return Stack(
       children: [
         GameWidget(game: game),
+        // スコア表示
+        Positioned(
+          top: 50,
+          left: 0,
+          right: 0,
+          child: ValueListenableBuilder<int>(
+            valueListenable: game.hitCount,
+            builder: (context, count, child) {
+              return Text(
+                'HIT: $count',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 32,
+                  fontWeight: FontWeight.bold,
+                  shadows: [
+                    Shadow(blurRadius: 4, color: Colors.black),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
         Positioned(
           bottom: 30,
           left: 0,
@@ -179,6 +204,15 @@ class RobotArmGame extends Forge2DGame {
 
   bool _isStraightening = false;
 
+  // ヒットカウント
+  final ValueNotifier<int> hitCount = ValueNotifier<int>(0);
+
+  // 敵リスト
+  final List<Enemy> enemies = [];
+
+  // ヒットした敵のキュー（物理エンジンロック中は処理を遅延）
+  final List<Enemy> _hitQueue = [];
+
   @override
   Color backgroundColor() => const Color(0xFF222222);
 
@@ -233,12 +267,83 @@ class RobotArmGame extends Forge2DGame {
       ..maxMotorTorque = 5000.0;
     elbowJoint = RevoluteJoint(elbowJointDef);
     world.createJoint(elbowJoint!);
+
+    // --- 敵を配置 ---
+    await _spawnEnemies();
   }
+
+  // アームの届く範囲の定数
+  static const double armReachMin = 6.0;  // 最小到達距離
+  static const double armReachMax = 13.0; // 最大到達距離（上腕7 + 前腕6）
+  static final Vector2 shoulderPos = Vector2(0, -7); // 肩のジョイント位置
+
+  final Random _random = Random();
+
+  /// アームの届く範囲内のランダムな位置を生成
+  Vector2 _getRandomPositionInArmReach() {
+    // 肩を中心とした円環内にランダム配置
+    final angle = _random.nextDouble() * 2 * pi;
+    final distance = armReachMin + _random.nextDouble() * (armReachMax - armReachMin);
+    return Vector2(
+      shoulderPos.x + cos(angle) * distance,
+      shoulderPos.y + sin(angle) * distance,
+    );
+  }
+
+  Future<void> _spawnEnemies() async {
+    // 5体の敵をアームの届く範囲内にランダム配置
+    for (int i = 0; i < 5; i++) {
+      final pos = _getRandomPositionInArmReach();
+      final enemy = Enemy(position: pos, radius: 1.0);
+      enemies.add(enemy);
+      await world.add(enemy);
+    }
+  }
+
+  void _onEnemyHit(Enemy enemy) {
+    // キューに追加（重複防止）
+    if (!_hitQueue.contains(enemy)) {
+      _hitQueue.add(enemy);
+    }
+  }
+
+  /// 腕の先端のワールド座標を取得
+  Vector2 get armTipPosition {
+    // 前腕のローカル座標で先端は (0, 3.5) の位置
+    return foreArm.body.worldPoint(Vector2(0, 3.5));
+  }
+
+  /// 腕の先端と敵の当たり判定をチェック
+  void _checkTipCollisions() {
+    final tipPos = armTipPosition;
+    for (final enemy in enemies) {
+      final distance = tipPos.distanceTo(enemy.body.position);
+      final hitDistance = tipRadius + enemy.radius;
+      if (distance < hitDistance) {
+        _onEnemyHit(enemy);
+      }
+    }
+  }
+
+  // 先端の当たり判定用の定数
+  static const double tipRadius = 0.8; // 先端の当たり判定の半径
 
   // --- 【重要】強制更新ロジック ---
   @override
   void update(double dt) {
     super.update(dt);
+
+    // ヒットキューを処理
+    if (_hitQueue.isNotEmpty) {
+      for (final enemy in _hitQueue) {
+        hitCount.value++;
+        enemy.respawn();
+      }
+      _hitQueue.clear();
+    }
+
+    // 腕の先端の当たり判定
+    _checkTipCollisions();
 
     if (_isStraightening) {
       // 1. 上腕の現在の角度を取得
@@ -343,5 +448,59 @@ class ArmPart extends BodyComponent {
     final jointPaint = Paint()..color = Colors.white.withValues(alpha: 0.5);
     canvas.drawCircle(Offset(0, -_size.y / 2 + 0.5), 0.4, jointPaint);
     canvas.drawCircle(Offset(0, _size.y / 2 - 0.5), 0.4, jointPaint);
+  }
+}
+
+// ---------------------------------------------------------
+// 5. 敵クラス（当たり判定用）
+// ---------------------------------------------------------
+class Enemy extends BodyComponent {
+  final Vector2 _initialPosition;
+  final double _radius;
+
+  Enemy({
+    required Vector2 position,
+    required double radius,
+  })  : _initialPosition = position.clone(),
+        _radius = radius;
+
+  /// 当たり判定用の半径
+  double get radius => _radius;
+
+  @override
+  RobotArmGame get game => findGame()! as RobotArmGame;
+
+  @override
+  Body createBody() {
+    final shape = CircleShape()..radius = _radius;
+    final fixtureDef = FixtureDef(shape)
+      ..restitution = 0.5
+      ..density = 1.0
+      ..friction = 0.3;
+    final bodyDef = BodyDef()
+      ..userData = this
+      ..position = _initialPosition
+      ..type = BodyType.static;
+    return world.createBody(bodyDef)..createFixture(fixtureDef);
+  }
+
+  void respawn() {
+    // アームの届く範囲内のランダムな位置に移動
+    final newPos = game._getRandomPositionInArmReach();
+    body.setTransform(newPos, 0);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    // 赤い丸で敵を描画
+    final paint = Paint()..color = Colors.redAccent;
+    canvas.drawCircle(Offset.zero, _radius, paint);
+
+    // 白い枠線
+    final border = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.1;
+    canvas.drawCircle(Offset.zero, _radius, border);
   }
 }


### PR DESCRIPTION
- 敵（Enemy）クラスを追加し、赤い丸として描画
  - 腕の先端（foreArmの先端）に円形の当たり判定を実装
  - 敵をアームの届く範囲内（半径6〜13）にランダム配置
  - ヒット時に敵がリスポーン、カウントを画面上部に表示