### PR TITLE
feat: タイトル画面とカウントダウン機能を追加 (#14, #15)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,8 @@ void main() async {
 // ---------------------------------------------------------
 // 0. アプリ全体の画面管理
 // ---------------------------------------------------------
+enum AppScreen { title, countdown, game }
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -32,20 +34,28 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  bool _showTitle = true;
+  AppScreen _currentScreen = AppScreen.title;
+
+  void _startCountdown() {
+    setState(() {
+      _currentScreen = AppScreen.countdown;
+    });
+  }
 
   void _startGame() {
     setState(() {
-      _showTitle = false;
+      _currentScreen = AppScreen.game;
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: _showTitle
-          ? TitleScreen(onStart: _startGame)
-          : const GameWrapper(),
+      body: switch (_currentScreen) {
+        AppScreen.title => TitleScreen(onStart: _startCountdown),
+        AppScreen.countdown => CountdownScreen(onComplete: _startGame),
+        AppScreen.game => const GameWrapper(),
+      },
     );
   }
 }
@@ -94,6 +104,77 @@ class TitleScreen extends StatelessWidget {
                   fontSize: 24,
                   fontWeight: FontWeight.w300,
                 ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------
+// 0.6. カウントダウン画面
+// ---------------------------------------------------------
+class CountdownScreen extends StatefulWidget {
+  final VoidCallback onComplete;
+
+  const CountdownScreen({super.key, required this.onComplete});
+
+  @override
+  State<CountdownScreen> createState() => _CountdownScreenState();
+}
+
+class _CountdownScreenState extends State<CountdownScreen> {
+  int _count = 3;
+  bool _showGameStart = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _startCountdown();
+  }
+
+  void _startCountdown() async {
+    // 3, 2, 1 カウントダウン
+    for (int i = 3; i >= 1; i--) {
+      if (!mounted) return;
+      setState(() {
+        _count = i;
+        _showGameStart = false;
+      });
+      await Future.delayed(const Duration(seconds: 1));
+    }
+
+    // 0 → ゲームスタート表示
+    if (!mounted) return;
+    setState(() {
+      _count = 0;
+      _showGameStart = true;
+    });
+    await Future.delayed(const Duration(seconds: 1));
+
+    // ゲーム画面へ遷移
+    if (!mounted) return;
+    widget.onComplete();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: const Color(0xFF222222),
+      child: Center(
+        child: Text(
+          _showGameStart ? 'ゲームスタート' : '$_count',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: _showGameStart ? 48 : 120,
+            fontWeight: FontWeight.bold,
+            shadows: const [
+              Shadow(
+                blurRadius: 10,
+                color: Colors.blueAccent,
+                offset: Offset(0, 0),
               ),
             ],
           ),


### PR DESCRIPTION
- アプリ起動時にタイトル画面を表示
  - 画面タップでカウントダウン開始
  - 3→2→1→ゲームスタート と1秒ごとに表示
  - カウントダウン後にゲーム画面へ遷移

Clode #14, #15