### PR TITLE
ble_manager.dart（案2）

### DIFF
--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -39,7 +39,7 @@ class BleManager {
   // --- 定数: ポンプ制御 (送信)  ---
   static const String _svcPumpUuid = UUID_SVC_WATER_PUMP;
   static const String _chrPumpUuid = UUID_CHR_WATER_PUMP;
-  BluetoothCharacteristic? _pumpCharacteristic;
+  final List<BluetoothCharacteristic> _pumpCharacteristics = [];
 
   // --- StreamControllers ---
   final _accelDataController = StreamController<AccelData>.broadcast();
@@ -153,8 +153,8 @@ class BleManager {
           }
 
           if (charUuid == _chrPumpUuid.toLowerCase()) {
-            // ポンプ用のCharacteristicとして保存
-            _pumpCharacteristic = c;
+            // ポンプ用のCharacteristicをリストに追加
+            _pumpCharacteristics.add(c);
             _printLog("ポンプ(送信)経路確保: $name");
           }
         }
@@ -182,20 +182,19 @@ class BleManager {
   }
 
   Future<void> sendBool(bool value) async {
-    // _pumpCharacteristic から取得する
-    BluetoothCharacteristic? target = _pumpCharacteristic;
-    
-    if (_pumpCharacteristic == null) {
+    if (_pumpCharacteristics.isEmpty) {
       _printLog("送信不可: ポンプ制御用の接続が見つかりません");
       return;
     }
 
-    try {
-      // 1 or 0 を送信
-      await target!.write([value ? 1 : 0], withoutResponse: true);
-      _printLog("ポンプ送信: ${value ? 'ON' : 'OFF'}");
-    } catch (e) {
-      _printLog("送信エラー: $e");
+    // 全てのポンプCharacteristicに送信
+    for (final c in _pumpCharacteristics) {
+      try {
+        await c.write([value ? 1 : 0], withoutResponse: true);
+        _printLog("ポンプ送信: ${value ? 'ON' : 'OFF'}");
+      } catch (e) {
+        _printLog("送信エラー: $e");
+      }
     }
   }
 
@@ -215,6 +214,7 @@ class BleManager {
 
     _devices.clear();
     _characteristics.clear();
+    _pumpCharacteristics.clear();
     _updateConnectedList();
     _printLog("全切断しました");
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -852,8 +852,10 @@ class RobotArmGame extends Forge2DGame {
   }
 
   /// タップでゲームクリア画面に遷移
-  void proceedToGameClear() {
+  void proceedToGameClear() async {
     if (_isCleared) {
+      // 遷移前にポンプ送信を保証
+      await bleManager.sendBool(true);
       onGameClear?.call();
     }
   }


### PR DESCRIPTION
- 42行目: List<BluetoothCharacteristic> _pumpCharacteristics = [] に変更
  - 155-159行目: リストに追加
  - 184-199行目: 全てのCharacteristicにループで送信
  - 217行目: 切断時に_pumpCharacteristics.clear()

  main.dart（案3）

  - 855-861行目: proceedToGameClear()をasyncにし、遷移前にawait bleManager.sendBool(true)を実行

  これで：
  1. どのデバイスにポンプがあっても確実に送信される（案2）
  2. 画面遷移時にも再送信して二重に保証（案3）