### PR TITLE
デバッグビルドのみ戦闘シーン中央に透明な攻撃トリガーボタンを追加

### DIFF
--- a/lib/screens/game_wrapper.dart
+++ b/lib/screens/game_wrapper.dart
@@ -193,6 +193,21 @@ class _GameWrapperState extends State<GameWrapper> {
           ),
         ),
         if (kDebugMode)
+          Positioned.fill(
+            child: Center(
+              child: GestureDetector(
+                onTapDown: (_) => _game.startStraightening(),
+                onTapUp: (_) => _game.stopStraightening(),
+                onTapCancel: () => _game.stopStraightening(),
+                child: Container(
+                  width: 200,
+                  height: 200,
+                  color: Colors.transparent,
+                ),
+              ),
+            ),
+          ),
+        if (kDebugMode)
           Positioned(
             top: 10,
             right: 10,


### PR DESCRIPTION
close #99 

## 概要

デバッグビルドのみ戦闘シーン中央に透明な攻撃トリガーボタンを追加しました。