### PR TITLE
ユガロック戦の腕を二重振り子から固定+伸展モードに変更する

### DIFF
--- a/assets/game_config.json
+++ b/assets/game_config.json
@@ -10,5 +10,6 @@
   "straighteningDuration": 0.2,
   "randomChangeInterval": 0.3,
   "shoulderSpeedRange": 24.0,
-  "elbowSpeedRange": 36.0
+  "elbowSpeedRange": 36.0,
+  "elbowBentAngle": 1.5707963267948966
 }

--- a/lib/debug/debug_config_overlay.dart
+++ b/lib/debug/debug_config_overlay.dart
@@ -280,6 +280,13 @@ class _DebugConfigOverlayState extends State<DebugConfigOverlay>
       value: _config.elbowSpeedRange,
       onChanged: (v) => _updateConfig((c) => c.copyWith(elbowSpeedRange: v)),
     ),
+    _FieldMeta(
+      label: 'elbowBentAngle',
+      displayName: '肘の曲げ角度',
+      steps: const [0.05, 0.5],
+      value: _config.elbowBentAngle,
+      onChanged: (v) => _updateConfig((c) => c.copyWith(elbowBentAngle: v)),
+    ),
   ];
 
   Widget _buildGameTab() {

--- a/lib/game/game_config.dart
+++ b/lib/game/game_config.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flame_forge2d/flame_forge2d.dart';
 
 import '../interfaces/json_exportable.dart';
@@ -20,6 +22,7 @@ class GameConfig implements JsonExportable {
 
   final double shoulderSpeedRange;
   final double elbowSpeedRange;
+  final double elbowBentAngle;
 
   GameConfig({
     Vector2? gravity,
@@ -34,6 +37,7 @@ class GameConfig implements JsonExportable {
     double? randomChangeInterval,
     double? shoulderSpeedRange,
     double? elbowSpeedRange,
+    double? elbowBentAngle,
   }) : gravity = gravity ?? Vector2(0, 15),
        zoom = zoom ?? 20.0,
        shoulderTorque = shoulderTorque ?? 8000.0,
@@ -45,7 +49,8 @@ class GameConfig implements JsonExportable {
        straighteningDuration = straighteningDuration ?? 0.2,
        randomChangeInterval = randomChangeInterval ?? 0.3,
        shoulderSpeedRange = shoulderSpeedRange ?? 24.0,
-       elbowSpeedRange = elbowSpeedRange ?? 36.0;
+       elbowSpeedRange = elbowSpeedRange ?? 36.0,
+       elbowBentAngle = elbowBentAngle ?? pi / 2;
 
   factory GameConfig.defaultConfig() => GameConfig();
 
@@ -74,6 +79,7 @@ class GameConfig implements JsonExportable {
       randomChangeInterval: (json['randomChangeInterval'] as num?)?.toDouble(),
       shoulderSpeedRange: (json['shoulderSpeedRange'] as num?)?.toDouble(),
       elbowSpeedRange: (json['elbowSpeedRange'] as num?)?.toDouble(),
+      elbowBentAngle: (json['elbowBentAngle'] as num?)?.toDouble(),
     );
   }
 
@@ -92,6 +98,7 @@ class GameConfig implements JsonExportable {
       'randomChangeInterval': randomChangeInterval,
       'shoulderSpeedRange': shoulderSpeedRange,
       'elbowSpeedRange': elbowSpeedRange,
+      'elbowBentAngle': elbowBentAngle,
     };
   }
 
@@ -116,6 +123,7 @@ class GameConfig implements JsonExportable {
     double? randomChangeInterval,
     double? shoulderSpeedRange,
     double? elbowSpeedRange,
+    double? elbowBentAngle,
   }) {
     return GameConfig(
       gravity: gravity ?? this.gravity,
@@ -131,6 +139,7 @@ class GameConfig implements JsonExportable {
       randomChangeInterval: randomChangeInterval ?? this.randomChangeInterval,
       shoulderSpeedRange: shoulderSpeedRange ?? this.shoulderSpeedRange,
       elbowSpeedRange: elbowSpeedRange ?? this.elbowSpeedRange,
+      elbowBentAngle: elbowBentAngle ?? this.elbowBentAngle,
     );
   }
 }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -27,6 +27,9 @@ class RobotArmGame extends Forge2DGame {
   final HpBarConfig _playerHpConfig;
   final HpBarConfig _enemyHpConfig;
 
+  /// true: アシンクロン戦の二重振り子モード / false: ユガロック戦の固定モード
+  final bool enablePendulum;
+
   RobotArmGame({
     this.onWin,
     this.onLose,
@@ -36,6 +39,7 @@ class RobotArmGame extends Forge2DGame {
     required EnemyConfig enemyConfig,
     HpBarConfig? playerHpConfig,
     HpBarConfig? enemyHpConfig,
+    this.enablePendulum = true,
   }) : _config = config,
        _layout = layout,
        _enemyConfig = enemyConfig,
@@ -57,6 +61,9 @@ class RobotArmGame extends Forge2DGame {
   bool isRandomMode = false;
   final Random _random = Random();
   double _randomChangeTimer = 0;
+
+  // 固定モード(ユガロック戦)用
+  double _fixedShoulderAngle = 0;
 
   // ヒットチェック用
   final List<Enemy> enemies = [];
@@ -164,7 +171,44 @@ class RobotArmGame extends Forge2DGame {
     elbowJoint = RevoluteJoint(elbowJointDef);
     world.createJoint(elbowJoint!);
 
-    startRandomMode();
+    if (enablePendulum) {
+      startRandomMode();
+    } else {
+      // ユガロック戦: 肩を敵の方向へ向けて固定し、肘は少し曲げた姿勢で待機させる
+      _fixedShoulderAngle = _calcShoulderAngleTowardEnemy();
+      upperArm.body.setTransform(upperArm.body.position, _fixedShoulderAngle);
+      foreArm.body.setTransform(
+        foreArm.body.position,
+        _fixedShoulderAngle + _config.elbowBentAngle,
+      );
+    }
+  }
+
+  /// 腕を伸ばした状態(肘が伸びきった状態)の先端が敵の方向を向くような肩関節の角度を求める
+  double _calcShoulderAngleTowardEnemy() {
+    final sj = _layout.shoulderJoint;
+    final ej = _layout.elbowJoint;
+    final shoulderPivot = shoulder.body.worldPoint(
+      Vector2(sj.anchorAX, sj.anchorAY),
+    );
+
+    // 上腕・前腕がともに角度0(伸びきった状態)のとき、肩関節ピボットから見た先端方向。
+    // 初期配置の各パーツ位置はジョイント制約と整合していないため、
+    // ローカルアンカー/オフセットのみから幾何的に算出する。
+    final straightTipDir =
+        Vector2(ej.anchorAX, ej.anchorAY) -
+        Vector2(ej.anchorBX, ej.anchorBY) +
+        Vector2(0, _layout.armTipLocalY) -
+        Vector2(sj.anchorBX, sj.anchorBY);
+
+    final enemyPos = Vector2(
+      _config.shoulderPos.x + _config.armLength + _config.enemyRadius,
+      0,
+    );
+    final enemyDir = enemyPos - shoulderPivot;
+
+    return atan2(enemyDir.y, enemyDir.x) -
+        atan2(straightTipDir.y, straightTipDir.x);
   }
 
   Future<void> _spawnEnemies() async {
@@ -312,6 +356,20 @@ class RobotArmGame extends Forge2DGame {
       if (_randomChangeTimer >= _config.randomChangeInterval) {
         _randomChangeTimer = 0;
         _applyRandomMovement();
+      }
+    }
+
+    if (!enablePendulum) {
+      // ユガロック戦: 肩を固定し、攻撃中以外は肘を曲げた姿勢に固定する
+      upperArm.body.setTransform(upperArm.body.position, _fixedShoulderAngle);
+      upperArm.body.angularVelocity = 0;
+
+      if (!_isStraightening) {
+        foreArm.body.setTransform(
+          foreArm.body.position,
+          _fixedShoulderAngle + _config.elbowBentAngle,
+        );
+        foreArm.body.angularVelocity = 0;
       }
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -173,6 +173,8 @@ class _MyAppState extends State<MyApp> {
             BattleStage.yugarock => 'ヒーロー、ここで倒れる！',
             BattleStage.asyncron => '戦いは怪獣の勝利に終わった！',
           },
+          // 振り子動作はアシンクロン戦のみの難易度調整。ユガロック戦は肩・肘を固定する。
+          enablePendulum: _currentStage == BattleStage.asyncron,
         ),
         AppScreen.result => ResultScreen(
           result: _currentResult,

--- a/lib/screens/game_wrapper.dart
+++ b/lib/screens/game_wrapper.dart
@@ -16,6 +16,7 @@ class GameWrapper extends StatefulWidget {
   final VoidCallback onLose;
   final BleService bleService;
   final String defeatMessage;
+  final bool enablePendulum;
 
   const GameWrapper({
     super.key,
@@ -23,6 +24,7 @@ class GameWrapper extends StatefulWidget {
     required this.onLose,
     required this.bleService,
     required this.defeatMessage,
+    required this.enablePendulum,
   });
 
   @override
@@ -70,6 +72,7 @@ class _GameWrapperState extends State<GameWrapper> {
       enemyConfig: _enemyConfig,
       playerHpConfig: _playerHpConfig,
       enemyHpConfig: _enemyHpConfig,
+      enablePendulum: widget.enablePendulum,
     );
   }
 

--- a/test/game/game_config_test.dart
+++ b/test/game/game_config_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -23,6 +24,7 @@ void main() {
       expect(config.randomChangeInterval, 0.3);
       expect(config.shoulderSpeedRange, 24.0);
       expect(config.elbowSpeedRange, 36.0);
+      expect(config.elbowBentAngle, pi / 2);
     });
 
     test('defaultConfig でデフォルト値が返る', () {
@@ -45,6 +47,7 @@ void main() {
         'randomChangeInterval': 0.6,
         'shoulderSpeedRange': 30.0,
         'elbowSpeedRange': 50.0,
+        'elbowBentAngle': -0.8,
       };
 
       final config = GameConfig.fromJson(json);
@@ -62,6 +65,7 @@ void main() {
       expect(config.randomChangeInterval, 0.6);
       expect(config.shoulderSpeedRange, 30.0);
       expect(config.elbowSpeedRange, 50.0);
+      expect(config.elbowBentAngle, -0.8);
     });
 
     test('toJson 往復で値が保持される', () {
@@ -86,6 +90,7 @@ void main() {
       expect(restored.randomChangeInterval, original.randomChangeInterval);
       expect(restored.shoulderSpeedRange, original.shoulderSpeedRange);
       expect(restored.elbowSpeedRange, original.elbowSpeedRange);
+      expect(restored.elbowBentAngle, original.elbowBentAngle);
     });
 
     test('fromJson で欠損フィールドはデフォルト値', () {


### PR DESCRIPTION
close #98

## 概要

アシンクロン戦の振り子動作は難易度調整のためアシンクロン戦専用とし、ユガロック戦では肩を敵方向へ固定、肘は90度曲げた姿勢で待機させ、攻撃タイミングで肘が伸びて敵に当たるようにした。