### PR TITLE
chore: アプリ名を syncro_gattai_spaholder_app に変更する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ BLE対応M5Stack 2台の加速度センサーで操作するFlutter製物理演�
 | Dart SDK | ^3.10.3 |
 | Flame | ^1.34.0 + flame_forge2d ^0.19.2+2 |
 | BLE | flutter_blue_plus ^2.0.2 |
-| パッケージ名 | spajam2025_app |
+| パッケージ名 | syncro_gattai_spaholder_app |
 
 ## コマンド
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.spajam2025_app"
+    namespace = "com.example.syncro_gattai_spaholder_app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.spajam2025_app"
+        applicationId = "com.example.syncro_gattai_spaholder_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <!-- legacy for Android 9 or lower -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
     <application
-        android:label="spajam2025_app"
+        android:label="真黒合体スパホルダー"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/example/syncro_gattai_spaholder_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/syncro_gattai_spaholder_app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.spajam2025_app
+package com.example.syncro_gattai_spaholder_app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.spajam2025App;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.syncro_gattai_spaholder_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -495,7 +495,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.spajam2025App.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.syncro_gattai_spaholder_app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -513,7 +513,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.spajam2025App.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.syncro_gattai_spaholder_app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -529,7 +529,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.spajam2025App.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.syncro_gattai_spaholder_app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -661,7 +661,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.spajam2025App;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.syncro_gattai_spaholder_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -684,7 +684,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.spajam2025App;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.syncro_gattai_spaholder_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Spajam2025 App</string>
+	<string>真黒合体スパホルダー</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>spajam2025_app</string>
+	<string>syncro_gattai_spaholder_app</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: spajam2025_app
+name: syncro_gattai_spaholder_app
 description: "A new Flutter project."
 publish_to: 'none'
 version: 1.0.0+1

--- a/test/debug/debug_config_overlay_test.dart
+++ b/test/debug/debug_config_overlay_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/debug/debug_config_overlay.dart';
-import 'package:spajam2025_app/game/arm_layout_config.dart';
-import 'package:spajam2025_app/game/enemy_config.dart';
-import 'package:spajam2025_app/game/game_config.dart';
-import 'package:spajam2025_app/game/hp_bar_config.dart';
+import 'package:syncro_gattai_spaholder_app/debug/debug_config_overlay.dart';
+import 'package:syncro_gattai_spaholder_app/game/arm_layout_config.dart';
+import 'package:syncro_gattai_spaholder_app/game/enemy_config.dart';
+import 'package:syncro_gattai_spaholder_app/game/game_config.dart';
+import 'package:syncro_gattai_spaholder_app/game/hp_bar_config.dart';
 
 void main() {
   Widget buildTestWidget({

--- a/test/game/arm_layout_config_test.dart
+++ b/test/game/arm_layout_config_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/arm_layout_config.dart';
-import 'package:spajam2025_app/game/part_config.dart';
-import 'package:spajam2025_app/interfaces/json_exportable.dart';
+import 'package:syncro_gattai_spaholder_app/game/arm_layout_config.dart';
+import 'package:syncro_gattai_spaholder_app/game/part_config.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/json_exportable.dart';
 
 void main() {
   group('ArmLayoutConfig', () {

--- a/test/game/components/enemy_test.dart
+++ b/test/game/components/enemy_test.dart
@@ -1,8 +1,8 @@
 import 'package:flame_forge2d/flame_forge2d.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/components/enemy.dart';
-import 'package:spajam2025_app/interfaces/damageable.dart';
-import 'package:spajam2025_app/interfaces/hp_readable.dart';
+import 'package:syncro_gattai_spaholder_app/game/components/enemy.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/damageable.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/hp_readable.dart';
 
 void main() {
   group('Enemy HP', () {

--- a/test/game/components/hp_bar_test.dart
+++ b/test/game/components/hp_bar_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/components/hp_bar.dart';
-import 'package:spajam2025_app/interfaces/hp_readable.dart';
+import 'package:syncro_gattai_spaholder_app/game/components/hp_bar.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/hp_readable.dart';
 
 class _MockHpReadable implements HpReadable {
   @override

--- a/test/game/enemy_config_test.dart
+++ b/test/game/enemy_config_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/enemy_config.dart';
-import 'package:spajam2025_app/interfaces/json_exportable.dart';
+import 'package:syncro_gattai_spaholder_app/game/enemy_config.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/json_exportable.dart';
 
 void main() {
   group('EnemyConfig', () {

--- a/test/game/game_config_test.dart
+++ b/test/game/game_config_test.dart
@@ -3,8 +3,8 @@ import 'dart:math';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/game_config.dart';
-import 'package:spajam2025_app/interfaces/json_exportable.dart';
+import 'package:syncro_gattai_spaholder_app/game/game_config.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/json_exportable.dart';
 
 void main() {
   group('GameConfig', () {

--- a/test/game/hp_bar_config_test.dart
+++ b/test/game/hp_bar_config_test.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/hp_bar_config.dart';
-import 'package:spajam2025_app/interfaces/json_exportable.dart';
+import 'package:syncro_gattai_spaholder_app/game/hp_bar_config.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/json_exportable.dart';
 
 void main() {
   group('HpBarConfig', () {

--- a/test/game/joint_config_test.dart
+++ b/test/game/joint_config_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/joint_config.dart';
+import 'package:syncro_gattai_spaholder_app/game/joint_config.dart';
 
 void main() {
   group('JointConfig', () {

--- a/test/game/part_config_test.dart
+++ b/test/game/part_config_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/game/part_config.dart';
+import 'package:syncro_gattai_spaholder_app/game/part_config.dart';
 
 void main() {
   group('PartConfig', () {

--- a/test/interfaces/damageable_test.dart
+++ b/test/interfaces/damageable_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/interfaces/damageable.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/damageable.dart';
 
 class _TestDamageable implements Damageable {
   double hp = 100;

--- a/test/interfaces/hp_readable_test.dart
+++ b/test/interfaces/hp_readable_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/interfaces/hp_readable.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/hp_readable.dart';
 
 class _TestHpReadable implements HpReadable {
   @override

--- a/test/interfaces/json_exportable_test.dart
+++ b/test/interfaces/json_exportable_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/interfaces/json_exportable.dart';
+import 'package:syncro_gattai_spaholder_app/interfaces/json_exportable.dart';
 
 class _TestExportable implements JsonExportable {
   final String name;

--- a/test/mixins/asset_loadable_test.dart
+++ b/test/mixins/asset_loadable_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/mixins/asset_loadable.dart';
+import 'package:syncro_gattai_spaholder_app/mixins/asset_loadable.dart';
 
 void main() {
   group('AssetLoadable', () {

--- a/test/models/accel_data_test.dart
+++ b/test/models/accel_data_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/models/accel_data.dart';
+import 'package:syncro_gattai_spaholder_app/models/accel_data.dart';
 
 void main() {
   group('AccelData', () {

--- a/test/screens/title_screen_test.dart
+++ b/test/screens/title_screen_test.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:spajam2025_app/accessors/ble_mock_accessor.dart';
-import 'package:spajam2025_app/screens/title_screen.dart';
+import 'package:syncro_gattai_spaholder_app/accessors/ble_mock_accessor.dart';
+import 'package:syncro_gattai_spaholder_app/screens/title_screen.dart';
 
 void main() {
   group('TitleScreen', () {


### PR DESCRIPTION
## 概要

アプリ名を syncro_gattai_spaholder_app に変更しました。また、ホーム画面の表示名は「真黒合体スパホルダー」としました。