### PR TITLE
スパホルダーがダメージを受けたとき両M5Stackに振動を送る

### DIFF
--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -408,6 +408,13 @@ class RobotArmGame extends Forge2DGame {
       }
       shoulder.takeDamage(damage);
       playerHp.value = shoulder.hp;
+      if (damage > 0) {
+        unawaited(
+          bleService.sendVibration(50).catchError((Object e) {
+            debugPrint('sendVibration error: $e');
+          }),
+        );
+      }
       debugPrint(
         '[Battle] ${enablePendulum ? "アシンクロン" : "ユガロック"}: ${action.nameJa} '
         '(damage=$damage, guarded=$isGuarding, '


### PR DESCRIPTION
isseu #121 

## 概要

ダメージを受けた際の振動モーターを動かすのを実装もれていたため対応しました。