### PR TITLE
戦闘時の細かな調整

### DIFF
--- a/lib/accessors/ble_mock_accessor.dart
+++ b/lib/accessors/ble_mock_accessor.dart
@@ -68,6 +68,13 @@ class BleMockAccessor implements BleService {
   }
 
   @override
+  Future<void> sendVibrationToRole(BleDeviceRole role, int strength) async {
+    debugPrint(
+      '[BLE Mock] sendVibrationToRole: ${role.deviceName} 強度 $strength',
+    );
+  }
+
+  @override
   Stream<Set<BleDeviceRole>> get connectedRolesStream =>
       _connectedRolesController.stream;
 

--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -328,6 +328,37 @@ class BleManager implements BleService {
   }
 
   @override
+  Future<void> sendVibrationToRole(BleDeviceRole role, int strength) async {
+    final deviceId = _deviceRoles.entries
+        .where((e) => e.value == role)
+        .map((e) => e.key)
+        .firstOrNull;
+    if (deviceId == null) {
+      _printLog("送信不可: ${role.deviceName} は接続されていません");
+      return;
+    }
+
+    final device = _devices[deviceId];
+    if (device == null) return;
+
+    final characteristic = _vibratorCharacteristics
+        .where((c) => c.remoteId == device.remoteId)
+        .firstOrNull;
+    if (characteristic == null) {
+      _printLog("送信不可: ${role.deviceName} の振動モーター制御用の接続が見つかりません");
+      return;
+    }
+
+    final clamped = strength.clamp(0, _vibratorMaxStrength);
+    try {
+      await characteristic.write([clamped], withoutResponse: true);
+      _printLog("振動モーター送信(${role.deviceName}): 強度 $clamped");
+    } catch (e) {
+      _printLog("送信エラー(${role.deviceName}): $e");
+    }
+  }
+
+  @override
   Future<void> disconnectAll() async {
     await _scanSub?.cancel();
     // スキャン停止も確実に行う

--- a/lib/game/combat/player_action_detector.dart
+++ b/lib/game/combat/player_action_detector.dart
@@ -14,9 +14,9 @@ class PlayerActionResult {
 
 /// BLE加速度センサー(2台分)の値からスパホルダーのシンクロ技の発動を検出する
 class PlayerActionDetector {
-  static const double thresholdX = 1.0;
-  static const double thresholdY = 0.75;
-  static const double thresholdZ = 2.0;
+  static const double thresholdX = 0.8;
+  static const double thresholdY = 0.9;
+  static const double thresholdZ = 1.8;
   static const int maxChargeLevel = 5;
 
   /// チャージレベルごとの攻撃倍率 (index = charge level)

--- a/lib/game/combat/player_action_detector.dart
+++ b/lib/game/combat/player_action_detector.dart
@@ -16,7 +16,7 @@ class PlayerActionResult {
 class PlayerActionDetector {
   static const double thresholdX = 0.8;
   static const double thresholdY = 0.9;
-  static const double thresholdZ = 1.8;
+  static const double thresholdZ = 1.7;
   static const int maxChargeLevel = 5;
 
   /// チャージレベルごとの攻撃倍率 (index = charge level)

--- a/lib/game/combat/player_action_detector.dart
+++ b/lib/game/combat/player_action_detector.dart
@@ -40,6 +40,7 @@ class PlayerActionDetector {
     Map<String, AccelData> accelData,
     List<String> connectedIds, {
     bool isGuarding = false,
+    bool isActionLocked = false,
   }) {
     final x = _bothExceed(accelData, connectedIds, (d) => d.x, thresholdX);
     final y = _bothExceed(
@@ -50,25 +51,32 @@ class PlayerActionDetector {
     );
     final z = _bothExceed(accelData, connectedIds, (d) => d.z, thresholdZ);
 
+    final prevX = _prevX;
+    final prevY = _prevY;
+    final prevZ = _prevZ;
+    _prevX = x;
+    _prevY = y;
+    _prevZ = z;
+
+    if (isActionLocked) {
+      return PlayerActionResult(PlayerActionType.none, _chargeLevel);
+    }
+
     PlayerActionResult result = PlayerActionResult(
       PlayerActionType.none,
       _chargeLevel,
     );
 
-    if (x && !_prevX && !isGuarding) {
+    if (x && !prevX && !isGuarding) {
       final level = _chargeLevel;
       _chargeLevel = 0;
       result = PlayerActionResult(PlayerActionType.attack, level);
-    } else if (y && !_prevY) {
+    } else if (y && !prevY) {
       result = PlayerActionResult(PlayerActionType.guard, _chargeLevel);
-    } else if (z && !_prevZ && _chargeLevel < maxChargeLevel && !isGuarding) {
+    } else if (z && !prevZ && _chargeLevel < maxChargeLevel && !isGuarding) {
       _chargeLevel++;
       result = PlayerActionResult(PlayerActionType.charge, _chargeLevel);
     }
-
-    _prevX = x;
-    _prevY = y;
-    _prevZ = z;
 
     return result;
   }

--- a/lib/game/combat/player_action_detector.dart
+++ b/lib/game/combat/player_action_detector.dart
@@ -33,10 +33,14 @@ class PlayerActionDetector {
   /// 現在のチャージレベル(0〜maxChargeLevel)
   int get chargeLevel => _chargeLevel;
 
+  /// チャージレベルを0にリセットする(ガード発動時などに使用)
+  void resetCharge() => _chargeLevel = 0;
+
   PlayerActionResult detect(
     Map<String, AccelData> accelData,
-    List<String> connectedIds,
-  ) {
+    List<String> connectedIds, {
+    bool isGuarding = false,
+  }) {
     final x = _bothExceed(accelData, connectedIds, (d) => d.x, thresholdX);
     final y = _bothExceed(
       accelData,
@@ -51,13 +55,13 @@ class PlayerActionDetector {
       _chargeLevel,
     );
 
-    if (x && !_prevX) {
+    if (x && !_prevX && !isGuarding) {
       final level = _chargeLevel;
       _chargeLevel = 0;
       result = PlayerActionResult(PlayerActionType.attack, level);
     } else if (y && !_prevY) {
       result = PlayerActionResult(PlayerActionType.guard, _chargeLevel);
-    } else if (z && !_prevZ && _chargeLevel < maxChargeLevel) {
+    } else if (z && !_prevZ && _chargeLevel < maxChargeLevel && !isGuarding) {
       _chargeLevel++;
       result = PlayerActionResult(PlayerActionType.charge, _chargeLevel);
     }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -461,7 +461,7 @@ class RobotArmGame extends Forge2DGame {
       playerHp.value = shoulder.hp;
       if (damage > 0) {
         unawaited(
-          bleService.sendVibration(50).catchError((Object e) {
+          bleService.sendVibration((damage * 2).toInt()).catchError((Object e) {
             debugPrint('sendVibration error: $e');
           }),
         );

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -132,6 +132,7 @@ class RobotArmGame extends Forge2DGame {
   /// 直近に発動した技名(スパホルダー/ユガロック)。1秒間表示後nullに戻る。
   final ValueNotifier<String?> playerActionLabel = ValueNotifier(null);
   final ValueNotifier<String?> enemyActionLabel = ValueNotifier(null);
+  final ValueNotifier<String?> asyncPendulumLabel = ValueNotifier(null);
   int _playerLabelGeneration = 0;
   int _enemyLabelGeneration = 0;
 
@@ -367,7 +368,21 @@ class RobotArmGame extends Forge2DGame {
       debugPrint(
         '[Battle] アシンクロン: ${_actionsConfig.asyncPendulum.nameJa} - 発動',
       );
-      _showCenterMessage('アシンクロンの技の影響を受けている...！');
+      asyncPendulumLabel.value = _actionsConfig.asyncPendulum.nameJa;
+      unawaited(
+        Future.delayed(const Duration(milliseconds: 2500), () {
+          asyncPendulumLabel.value = null;
+        }),
+      );
+      _showCenterMessage(
+        'アシンクロンの技の\n影響を受けている...！',
+        duration: const Duration(milliseconds: 2500),
+      );
+      unawaited(
+        bleService.sendVibration(25).catchError((Object e) {
+          debugPrint('sendVibration error: $e');
+        }),
+      );
     }
 
     if (_guardTimer > 0) {
@@ -499,11 +514,13 @@ class RobotArmGame extends Forge2DGame {
     );
   }
 
-  /// 画面中央にメッセージを2秒間表示する
-  void _showCenterMessage(String text) {
+  void _showCenterMessage(
+    String text, {
+    Duration duration = const Duration(seconds: 2),
+  }) {
     centerMessage.value = text;
     unawaited(
-      Future.delayed(const Duration(seconds: 2), () {
+      Future.delayed(duration, () {
         centerMessage.value = null;
       }),
     );

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -384,7 +384,10 @@ class RobotArmGame extends Forge2DGame {
       case PlayerActionType.guard:
         _guardTimer = _guardDuration;
         debugPrint('[Battle] スパホルダー: ${_actionsConfig.synchroGuard.nameJa}');
-        _showPlayerActionLabel(_actionsConfig.synchroGuard.nameJa);
+        _showPlayerActionLabel(
+          _actionsConfig.synchroGuard.nameJa,
+          duration: Duration(milliseconds: (_guardDuration * 1000).toInt()),
+        );
       case PlayerActionType.charge:
         if (isGuardingNow) break;
         debugPrint(
@@ -428,12 +431,15 @@ class RobotArmGame extends Forge2DGame {
     }
   }
 
-  /// スパホルダーの技名を1秒間表示する
-  void _showPlayerActionLabel(String text) {
+  /// スパホルダーの技名を表示する。durationを省略した場合は1秒間表示する。
+  void _showPlayerActionLabel(
+    String text, {
+    Duration duration = const Duration(seconds: 1),
+  }) {
     playerActionLabel.value = text;
     final generation = ++_playerLabelGeneration;
     unawaited(
-      Future.delayed(const Duration(seconds: 1), () {
+      Future.delayed(duration, () {
         if (_playerLabelGeneration == generation) {
           playerActionLabel.value = null;
         }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -347,12 +347,7 @@ class RobotArmGame extends Forge2DGame {
     _stopAllPhysics();
 
     unawaited(
-      Future.delayed(const Duration(seconds: 3), () async {
-        try {
-          await bleService.sendVibration(100);
-        } catch (e) {
-          debugPrint('sendVibration error: $e');
-        }
+      Future.delayed(const Duration(seconds: 3), () {
         onWin?.call();
       }),
     );

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -563,7 +563,6 @@ class RobotArmGame extends Forge2DGame {
     if (_isDefeated) return;
     _isDefeated = true;
     _stopAllPhysics();
-    showDefeatMessage.value = true;
 
     // 敗北時、スパホルダーを構成する各パーツを-45度傾けて倒れた姿勢にする
     const tiltAngle = -pi / 4;
@@ -580,9 +579,15 @@ class RobotArmGame extends Forge2DGame {
       foreArm.body.angle + tiltAngle,
     );
 
+    // 勝利と同じ3秒静止後にメッセージを表示し、さらに2秒後に遷移する
     unawaited(
       Future.delayed(const Duration(seconds: 3), () {
-        onLose?.call();
+        showDefeatMessage.value = true;
+        unawaited(
+          Future.delayed(const Duration(seconds: 2), () {
+            onLose?.call();
+          }),
+        );
       }),
     );
   }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -76,6 +76,25 @@ class RobotArmGame extends Forge2DGame {
   bool _isStraightening = false;
   double _straighteningTimer = 0;
 
+  /// シンクロチャージ発動後の技ロック時間(秒)
+  static const double _chargeLockDuration = 0.5;
+
+  /// シンクロアタック発動後のチャージレベル別ロック時間(秒)
+  static const List<double> _attackLockDurations = [
+    1.0,
+    1.1,
+    1.2,
+    1.5,
+    1.75,
+    2.0,
+  ];
+
+  /// シンクロチャージ発動後の技ロック残り時間(秒)
+  double _chargeActiveTimer = 0;
+
+  /// シンクロアタック発動後の技ロック残り時間(秒)
+  double _attackActiveTimer = 0;
+
   /// シンクロガードの効果時間(秒)
   static const double _guardDuration = 2.0;
 
@@ -359,27 +378,47 @@ class RobotArmGame extends Forge2DGame {
     if (_guardTimer > 0) {
       _guardTimer = (_guardTimer - dt).clamp(0, _guardDuration);
     }
+    if (_chargeActiveTimer > 0) {
+      _chargeActiveTimer = (_chargeActiveTimer - dt).clamp(
+        0,
+        _chargeLockDuration,
+      );
+    }
+    if (_attackActiveTimer > 0) {
+      _attackActiveTimer = (_attackActiveTimer - dt).clamp(
+        0,
+        _attackLockDurations.last,
+      );
+    }
 
     final isGuardingNow = _guardTimer > 0;
+    final isActionLocked =
+        _isStraightening || _chargeActiveTimer > 0 || _attackActiveTimer > 0;
     final playerResult = _playerActionDetector.detect(
       _accelData,
       _connectedIds,
       isGuarding: isGuardingNow,
+      isActionLocked: isActionLocked,
     );
     playerChargeLevel.value = _playerActionDetector.chargeLevel;
     switch (playerResult.type) {
       case PlayerActionType.attack:
-        if (isGuardingNow) break;
-        final multiplier =
-            PlayerActionDetector.chargeMultipliers[playerResult.chargeLevel];
+        final chargeLevel = playerResult.chargeLevel;
+        final multiplier = PlayerActionDetector.chargeMultipliers[chargeLevel];
         final damage = _actionsConfig.synchroAttack.power * multiplier;
         _pendingAttackDamage = damage;
+        _attackActiveTimer = _attackLockDurations[chargeLevel];
         debugPrint(
           '[Battle] スパホルダー: ${_actionsConfig.synchroAttack.nameJa} '
-          '(chargeLevel=${playerResult.chargeLevel}, '
+          '(chargeLevel=$chargeLevel, '
           'multiplier=$multiplier, damage=$damage) - ドリル始動',
         );
-        _showPlayerActionLabel(_actionsConfig.synchroAttack.nameJa);
+        _showPlayerActionLabel(
+          _actionsConfig.synchroAttack.nameJa,
+          duration: Duration(
+            milliseconds: (_attackLockDurations[chargeLevel] * 1000).toInt(),
+          ),
+        );
         startStraightening();
       case PlayerActionType.guard:
         _guardTimer = _guardDuration;
@@ -389,12 +428,17 @@ class RobotArmGame extends Forge2DGame {
           duration: Duration(milliseconds: (_guardDuration * 1000).toInt()),
         );
       case PlayerActionType.charge:
-        if (isGuardingNow) break;
+        _chargeActiveTimer = _chargeLockDuration;
         debugPrint(
           '[Battle] スパホルダー: ${_actionsConfig.synchroCharge.nameJa} '
           '(chargeLevel=${playerResult.chargeLevel})',
         );
-        _showPlayerActionLabel(_actionsConfig.synchroCharge.nameJa);
+        _showPlayerActionLabel(
+          _actionsConfig.synchroCharge.nameJa,
+          duration: Duration(
+            milliseconds: (_chargeLockDuration * 1000).toInt(),
+          ),
+        );
       case PlayerActionType.none:
         break;
     }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -360,13 +360,16 @@ class RobotArmGame extends Forge2DGame {
       _guardTimer = (_guardTimer - dt).clamp(0, _guardDuration);
     }
 
+    final isGuardingNow = _guardTimer > 0;
     final playerResult = _playerActionDetector.detect(
       _accelData,
       _connectedIds,
+      isGuarding: isGuardingNow,
     );
     playerChargeLevel.value = _playerActionDetector.chargeLevel;
     switch (playerResult.type) {
       case PlayerActionType.attack:
+        if (isGuardingNow) break;
         final multiplier =
             PlayerActionDetector.chargeMultipliers[playerResult.chargeLevel];
         final damage = _actionsConfig.synchroAttack.power * multiplier;
@@ -383,6 +386,7 @@ class RobotArmGame extends Forge2DGame {
         debugPrint('[Battle] スパホルダー: ${_actionsConfig.synchroGuard.nameJa}');
         _showPlayerActionLabel(_actionsConfig.synchroGuard.nameJa);
       case PlayerActionType.charge:
+        if (isGuardingNow) break;
         debugPrint(
           '[Battle] スパホルダー: ${_actionsConfig.synchroCharge.nameJa} '
           '(chargeLevel=${playerResult.chargeLevel})',

--- a/lib/interfaces/ble_service.dart
+++ b/lib/interfaces/ble_service.dart
@@ -8,6 +8,9 @@ abstract interface class BleService {
   Stream<List<String>> get connectedDevicesStream;
   List<String> get connectedDevices;
   Future<void> sendVibration(int strength);
+
+  /// 指定したロールのデバイスのみに振動を送る
+  Future<void> sendVibrationToRole(BleDeviceRole role, int strength);
   void dispose();
 
   /// 指定したロールのデバイスをスキャンして接続する

--- a/lib/screens/game_wrapper.dart
+++ b/lib/screens/game_wrapper.dart
@@ -12,6 +12,7 @@ import '../game/hp_bar_config.dart';
 import '../game/robot_arm_game.dart';
 import '../interfaces/ble_service.dart';
 import '../widgets/action_label_text.dart';
+import '../widgets/outlined_text.dart';
 import '../widgets/charge_level_indicator.dart';
 import '../widgets/exit_dialog.dart';
 import '../widgets/hold_button.dart';
@@ -204,7 +205,23 @@ class _GameWrapperState extends State<GameWrapper> {
                   if (label == null) return const SizedBox.shrink();
                   return ActionLabelText(
                     label: label,
-                    colors: const [Color(0xFF86D5FF), Color(0xFF2732FC)],
+                    colors: widget.enablePendulum
+                        ? const [Color(0xFFFF32F8), Color(0xFF730DB2)]
+                        : const [Color(0xFF86D5FF), Color(0xFF2732FC)],
+                  );
+                },
+              ),
+            ),
+            Positioned(
+              left: screenSize.width * 0.56,
+              top: screenSize.height * 0.12,
+              child: ValueListenableBuilder<String?>(
+                valueListenable: _game.asyncPendulumLabel,
+                builder: (context, label, _) {
+                  if (label == null) return const SizedBox.shrink();
+                  return ActionLabelText(
+                    label: label,
+                    colors: const [Color(0xFFFF32F8), Color(0xFF730DB2)],
                   );
                 },
               ),
@@ -232,16 +249,7 @@ class _GameWrapperState extends State<GameWrapper> {
                   child: Center(
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 24),
-                      child: Text(
-                        message,
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 28,
-                          fontWeight: FontWeight.bold,
-                          letterSpacing: 2,
-                        ),
-                      ),
+                      child: OutlinedText(text: message, fontSize: 28),
                     ),
                   ),
                 );

--- a/lib/screens/title_screen.dart
+++ b/lib/screens/title_screen.dart
@@ -138,6 +138,11 @@ class _TitleScreenState extends State<TitleScreen> {
 
     try {
       await _bleService.connectDevice(role);
+      unawaited(
+        _bleService.sendVibrationToRole(role, 10).catchError((Object e) {
+          debugPrint('振動エラー: $e');
+        }),
+      );
     } catch (e) {
       debugPrint('接続エラー: $e');
       _setState(role, _ConnectionUiState.idle, message: '接続に失敗しました');

--- a/lib/screens/title_screen.dart
+++ b/lib/screens/title_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import '../interfaces/ble_service.dart';
 import '../models/ble_device_role.dart';
 import '../widgets/connect_button.dart';
-import '../widgets/connection_status_label.dart';
+import '../widgets/outlined_text.dart';
 import '../widgets/start_button.dart';
 
 enum _ConnectionUiState { idle, connecting, connected, disconnecting }
@@ -211,7 +211,7 @@ class _TitleScreenState extends State<TitleScreen> {
           onTap: _onTapFor(role, state),
         ),
         if (message != null)
-          Positioned(top: -36, child: ConnectionStatusLabel(text: message)),
+          Positioned(top: -36, child: OutlinedText(text: message)),
       ],
     );
   }

--- a/lib/widgets/action_label_text.dart
+++ b/lib/widgets/action_label_text.dart
@@ -1,13 +1,21 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 /// 技名表示用テキスト。黒縁取り+グラデーション塗りのインパクトのある見た目にする。
 class ActionLabelText extends StatelessWidget {
   final String label;
   final List<Color> colors;
+  final double angle;
 
   static const _fontSize = 28.0;
 
-  const ActionLabelText({super.key, required this.label, required this.colors});
+  const ActionLabelText({
+    super.key,
+    required this.label,
+    required this.colors,
+    this.angle = -20 * math.pi / 180,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -16,27 +24,30 @@ class ActionLabelText extends StatelessWidget {
       fontWeight: FontWeight.bold,
     );
 
-    return Stack(
-      children: [
-        Text(
-          label,
-          style: textStyle.copyWith(
-            foreground: Paint()
-              ..style = PaintingStyle.stroke
-              ..strokeWidth = 4
-              ..color = Colors.black,
+    return Transform.rotate(
+      angle: angle,
+      child: Stack(
+        children: [
+          Text(
+            label,
+            style: textStyle.copyWith(
+              foreground: Paint()
+                ..style = PaintingStyle.stroke
+                ..strokeWidth = 4
+                ..color = Colors.black,
+            ),
           ),
-        ),
-        ShaderMask(
-          blendMode: BlendMode.srcIn,
-          shaderCallback: (bounds) => LinearGradient(
-            colors: colors,
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          ).createShader(bounds),
-          child: Text(label, style: textStyle.copyWith(color: Colors.white)),
-        ),
-      ],
+          ShaderMask(
+            blendMode: BlendMode.srcIn,
+            shaderCallback: (bounds) => LinearGradient(
+              colors: colors,
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+            ).createShader(bounds),
+            child: Text(label, style: textStyle.copyWith(color: Colors.white)),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/outlined_text.dart
+++ b/lib/widgets/outlined_text.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/material.dart';
 
-class ConnectionStatusLabel extends StatelessWidget {
+class OutlinedText extends StatelessWidget {
   final String text;
+  final double fontSize;
 
-  const ConnectionStatusLabel({super.key, required this.text});
+  const OutlinedText({
+    super.key,
+    required this.text,
+    this.fontSize = 16,
+  });
 
   @override
   Widget build(BuildContext context) {
-    const style = TextStyle(
-      fontSize: 16,
-      color: Color(0xFF1A1A1A),
+    final style = TextStyle(
+      fontSize: fontSize,
+      color: const Color(0xFF1A1A1A),
       fontWeight: FontWeight.bold,
     );
 

--- a/test/game/combat/player_action_detector_test.dart
+++ b/test/game/combat/player_action_detector_test.dart
@@ -46,13 +46,13 @@ void main() {
 
     test('Y軸(絶対値)がしきい値を超えるとguardを検出する', () {
       final detector = PlayerActionDetector();
-      final result = detector.detect(_both(y: -0.75), _ids);
+      final result = detector.detect(_both(y: -0.9), _ids);
       expect(result.type, PlayerActionType.guard);
     });
 
     test('guard中はisGuardingがtrueになる', () {
       final detector = PlayerActionDetector();
-      detector.detect(_both(y: 0.75), _ids);
+      detector.detect(_both(y: 0.9), _ids);
       expect(detector.isGuarding, true);
 
       detector.detect(_both(y: 0), _ids);


### PR DESCRIPTION
issue #121 

## 概要

戦闘時の細かな調整を行いました。

- シンクロ技の検出しきい値を調整（X: 1.0→0.8、Y: 0.75→0.9、Z: 2.0→1.7）
- シンクロアタック・チャージ中は他の技を発動不可にし、技ごとに硬直時間を設定（チャージ: 0.5秒、アタック: チャージレベル応じて1.0〜2.0秒）
- ガード中のワザ名表示時間をシールドアイコンと同じ2秒に統一
- 敗北時のフロー変更：3秒静止 → 敗北メッセージ表示 → 2秒後にリザルト画面へ遷移
- ダメージ時の振動強度をダメージ量×2に変更
- BLE接続時の振動を接続したデバイスのみに送信するよう変更（sendVibrationToRole を追加）
- アシンクロン技名（asyncPendulumLabel）の表示を追加：OutlinedText ウィジェット導入（ConnectionStatusLabel をリネーム・汎用化）、技名を #FF32F8/#730DB2 カラーの ActionLabelText で表示、アシンクロン戦の敵技名カラーも同色に統一、centerMessage を2.5秒表示に変更
- 技名ラベルを右上がり20度傾けて表示