### PR TITLE
ゲームの調整

### DIFF
--- a/lib/game/combat/player_action_detector.dart
+++ b/lib/game/combat/player_action_detector.dart
@@ -15,7 +15,7 @@ class PlayerActionResult {
 /// BLE加速度センサー(2台分)の値からスパホルダーのシンクロ技の発動を検出する
 class PlayerActionDetector {
   static const double thresholdX = 0.77;
-  static const double thresholdY = 0.95;
+  static const double thresholdY = 1.17;
   static const double thresholdZ = 1.65;
   static const int maxChargeLevel = 5;
 

--- a/lib/game/combat/player_action_detector.dart
+++ b/lib/game/combat/player_action_detector.dart
@@ -42,14 +42,13 @@ class PlayerActionDetector {
     bool isGuarding = false,
     bool isActionLocked = false,
   }) {
-    final x = _bothExceed(accelData, connectedIds, (d) => d.x, thresholdX);
-    final y = _bothExceed(
-      accelData,
-      connectedIds,
-      (d) => d.y.abs(),
-      thresholdY,
-    );
-    final z = _bothExceed(accelData, connectedIds, (d) => d.z, thresholdZ);
+    final xVal = _minAxisValue(accelData, connectedIds, (d) => d.x);
+    final yVal = _minAxisValue(accelData, connectedIds, (d) => d.y.abs());
+    final zVal = _minAxisValue(accelData, connectedIds, (d) => d.z);
+
+    final x = xVal != null && xVal >= thresholdX;
+    final y = yVal != null && yVal >= thresholdY;
+    final z = zVal != null && zVal >= thresholdZ;
 
     final prevX = _prevX;
     final prevY = _prevY;
@@ -62,35 +61,46 @@ class PlayerActionDetector {
       return PlayerActionResult(PlayerActionType.none, _chargeLevel);
     }
 
-    PlayerActionResult result = PlayerActionResult(
-      PlayerActionType.none,
-      _chargeLevel,
-    );
+    // 各軸の立ち上がりエッジと発動条件を確認
+    final xRising = x && !prevX && !isGuarding;
+    final yRising = y && !prevY;
+    final zRising = z && !prevZ && _chargeLevel < maxChargeLevel && !isGuarding;
 
-    if (x && !prevX && !isGuarding) {
-      final level = _chargeLevel;
-      _chargeLevel = 0;
-      result = PlayerActionResult(PlayerActionType.attack, level);
-    } else if (y && !prevY) {
-      result = PlayerActionResult(PlayerActionType.guard, _chargeLevel);
-    } else if (z && !prevZ && _chargeLevel < maxChargeLevel && !isGuarding) {
-      _chargeLevel++;
-      result = PlayerActionResult(PlayerActionType.charge, _chargeLevel);
+    if (!xRising && !yRising && !zRising) {
+      return PlayerActionResult(PlayerActionType.none, _chargeLevel);
     }
 
-    return result;
+    // 複数軸が同時に立ち上がった場合、「値 - 閾値」が最大の軸の技を発動
+    final xExcess = xRising ? xVal - thresholdX : double.negativeInfinity;
+    final yExcess = yRising ? yVal - thresholdY : double.negativeInfinity;
+    final zExcess = zRising ? zVal - thresholdZ : double.negativeInfinity;
+
+    if (xExcess >= yExcess && xExcess >= zExcess) {
+      final level = _chargeLevel;
+      _chargeLevel = 0;
+      return PlayerActionResult(PlayerActionType.attack, level);
+    } else if (yExcess >= zExcess) {
+      return PlayerActionResult(PlayerActionType.guard, _chargeLevel);
+    } else {
+      _chargeLevel++;
+      return PlayerActionResult(PlayerActionType.charge, _chargeLevel);
+    }
   }
 
-  bool _bothExceed(
+  /// 接続デバイス全台の軸値の最小値を返す。2台未満またはデータ欠損時はnullを返す。
+  double? _minAxisValue(
     Map<String, AccelData> accelData,
     List<String> connectedIds,
     double Function(AccelData) axis,
-    double threshold,
   ) {
-    if (connectedIds.length < 2) return false;
-    return connectedIds.every((id) {
+    if (connectedIds.length < 2) return null;
+    double? minVal;
+    for (final id in connectedIds) {
       final data = accelData[id];
-      return data != null && axis(data) >= threshold;
-    });
+      if (data == null) return null;
+      final val = axis(data);
+      if (minVal == null || val < minVal) minVal = val;
+    }
+    return minVal;
   }
 }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -584,61 +584,76 @@ class RobotArmGame extends Forge2DGame {
     playerGuardActive.value = _guardTimer > 0;
 
     if (_enemyActionScheduler.update(dt)) {
-      _enemyActingTimer = 2.0;
       final enemyActions = enablePendulum
           ? _actionsConfig.asyncronActions
           : _actionsConfig.yugarockActions;
       final actionIdx = _random.nextInt(enemyActions.length);
       final action = enemyActions[actionIdx];
-      final isGuarding = _guardTimer > 0;
-      var damage = action.power.toDouble();
-      if (isGuarding) {
-        final guardRate = 0.5 + _random.nextDouble() * 0.5;
-        damage = (damage * (1 - guardRate)).floorToDouble();
-      }
-      shoulder.takeDamage(damage);
-      playerHp.value = shoulder.hp;
-      // アシンクバキューム: アシンクロン自身がダメージの半分(繰り上げ)を回復
-      if (enablePendulum &&
-          actionIdx == 1 &&
-          damage > 0 &&
-          enemies.isNotEmpty) {
-        enemies.first.heal((damage / 2).ceilToDouble());
-        enemyHp.value = enemies.first.hp;
-      }
-      if (damage > 0) _startLunge(-1.0);
-      if (!_hpLowPlayed && playerHp.value <= _playerHpConfig.maxHp * 0.25) {
-        _hpLowPlayed = true;
-        unawaited(GameSe.hpLow.loop().then((p) => _hpLowPlayer = p));
-      }
-      if (damage > 0) {
-        unawaited(
-          bleService.sendVibration((damage * 4).toInt()).catchError((Object e) {
-            debugPrint('sendVibration error: $e');
-          }),
-        );
-      }
-      debugPrint(
-        '[Battle] ${enablePendulum ? "アシンクロン" : "ユガロック"}: ${action.nameJa} '
-        '(damage=$damage, guarded=$isGuarding, '
-        'playerHp=${shoulder.hp})',
+
+      // 攻撃1秒前に技名を予告表示（予告1秒 + 攻撃後2秒 = 計3秒間表示）
+      _showEnemyActionLabel(
+        action.nameJa,
+        duration: const Duration(seconds: 3),
       );
-      final enemySes = enablePendulum
-          ? [GameSe.asyncStream, GameSe.asyncVacuum]
-          : [GameSe.yugarockRoll, GameSe.yugarockFillIn];
-      enemySes[actionIdx].play();
-      if (enemies.isNotEmpty) {
-        final e = enemies.first;
-        e.showActionSprite(actionIdx);
-        if (!enablePendulum && actionIdx == 1) _enemyFillInActive = true;
-        unawaited(
-          Future.delayed(const Duration(seconds: 2), () {
-            e.clearActionSprite();
-            _enemyFillInActive = false;
-          }),
-        );
-      }
-      _showEnemyActionLabel(action.nameJa);
+
+      // 1秒後に実際の攻撃を発動
+      unawaited(
+        Future.delayed(const Duration(seconds: 1), () {
+          if (_isCleared || _isDefeated) return;
+
+          _enemyActingTimer = 2.0;
+          final isGuarding = _guardTimer > 0;
+          var damage = action.power.toDouble();
+          if (isGuarding) {
+            final guardRate = 0.5 + _random.nextDouble() * 0.5;
+            damage = (damage * (1 - guardRate)).floorToDouble();
+          }
+          shoulder.takeDamage(damage);
+          playerHp.value = shoulder.hp;
+          // アシンクバキューム: アシンクロン自身がダメージの半分(繰り上げ)を回復
+          if (enablePendulum &&
+              actionIdx == 1 &&
+              damage > 0 &&
+              enemies.isNotEmpty) {
+            enemies.first.heal((damage / 2).ceilToDouble());
+            enemyHp.value = enemies.first.hp;
+          }
+          if (damage > 0) _startLunge(-1.0);
+          if (!_hpLowPlayed && playerHp.value <= _playerHpConfig.maxHp * 0.25) {
+            _hpLowPlayed = true;
+            unawaited(GameSe.hpLow.loop().then((p) => _hpLowPlayer = p));
+          }
+          if (damage > 0) {
+            unawaited(
+              bleService.sendVibration((damage * 4).toInt()).catchError((
+                Object e,
+              ) {
+                debugPrint('sendVibration error: $e');
+              }),
+            );
+          }
+          debugPrint(
+            '[Battle] ${enablePendulum ? "アシンクロン" : "ユガロック"}: ${action.nameJa} '
+            '(damage=$damage, guarded=$isGuarding, '
+            'playerHp=${shoulder.hp})',
+          );
+          final enemySes = enablePendulum
+              ? [GameSe.asyncStream, GameSe.asyncVacuum]
+              : [GameSe.yugarockRoll, GameSe.yugarockFillIn];
+          enemySes[actionIdx].play();
+          if (enemies.isNotEmpty) {
+            final e = enemies.first;
+            e.showActionSprite(actionIdx);
+            if (!enablePendulum && actionIdx == 1) _enemyFillInActive = true;
+            unawaited(
+              Future.delayed(const Duration(seconds: 2), () {
+                e.clearActionSprite();
+                _enemyFillInActive = false;
+              }),
+            );
+          }
+        }),
+      );
     }
   }
 
@@ -658,12 +673,15 @@ class RobotArmGame extends Forge2DGame {
     );
   }
 
-  /// 敵の技名を2秒間表示する
-  void _showEnemyActionLabel(String text) {
+  /// 敵の技名を表示する。durationを省略した場合は2秒間表示する。
+  void _showEnemyActionLabel(
+    String text, {
+    Duration duration = const Duration(seconds: 2),
+  }) {
     enemyActionLabel.value = text;
     final generation = ++_enemyLabelGeneration;
     unawaited(
-      Future.delayed(const Duration(seconds: 2), () {
+      Future.delayed(duration, () {
         if (_enemyLabelGeneration == generation) {
           enemyActionLabel.value = null;
         }

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -606,7 +606,7 @@ class RobotArmGame extends Forge2DGame {
           var damage = action.power.toDouble();
           if (isGuarding) {
             final guardRate = 0.5 + _random.nextDouble() * 0.5;
-            damage = (damage * (1 - guardRate)).floorToDouble();
+            damage = (damage * (1 - guardRate)).roundToDouble();
           }
           shoulder.takeDamage(damage);
           playerHp.value = shoulder.hp;

--- a/lib/game/robot_arm_game.dart
+++ b/lib/game/robot_arm_game.dart
@@ -593,10 +593,8 @@ class RobotArmGame extends Forge2DGame {
       final isGuarding = _guardTimer > 0;
       var damage = action.power.toDouble();
       if (isGuarding) {
-        damage = (damage - _actionsConfig.synchroGuard.power).clamp(
-          0,
-          double.infinity,
-        );
+        final guardRate = 0.5 + _random.nextDouble() * 0.5;
+        damage = (damage * (1 - guardRate)).floorToDouble();
       }
       shoulder.takeDamage(damage);
       playerHp.value = shoulder.hp;

--- a/test/game/combat/player_action_detector_test.dart
+++ b/test/game/combat/player_action_detector_test.dart
@@ -46,13 +46,13 @@ void main() {
 
     test('Y軸(絶対値)がしきい値を超えるとguardを検出する', () {
       final detector = PlayerActionDetector();
-      final result = detector.detect(_both(y: -1.0), _ids);
+      final result = detector.detect(_both(y: -1.2), _ids);
       expect(result.type, PlayerActionType.guard);
     });
 
     test('guard中はisGuardingがtrueになる', () {
       final detector = PlayerActionDetector();
-      detector.detect(_both(y: 1.0), _ids);
+      detector.detect(_both(y: 1.2), _ids);
       expect(detector.isGuarding, true);
 
       detector.detect(_both(y: 0), _ids);

--- a/test/game/combat/player_action_detector_test.dart
+++ b/test/game/combat/player_action_detector_test.dart
@@ -46,17 +46,34 @@ void main() {
 
     test('Y軸(絶対値)がしきい値を超えるとguardを検出する', () {
       final detector = PlayerActionDetector();
-      final result = detector.detect(_both(y: -0.9), _ids);
+      final result = detector.detect(_both(y: -1.0), _ids);
       expect(result.type, PlayerActionType.guard);
     });
 
     test('guard中はisGuardingがtrueになる', () {
       final detector = PlayerActionDetector();
-      detector.detect(_both(y: 0.9), _ids);
+      detector.detect(_both(y: 1.0), _ids);
       expect(detector.isGuarding, true);
 
       detector.detect(_both(y: 0), _ids);
       expect(detector.isGuarding, false);
+    });
+
+    test('複数軸が同時に閾値を超えた場合、値 - 閾値の差分が最大の技を発動する', () {
+      // X: 1.0 - 0.77 = 0.23, Y: 1.1 - 0.95 = 0.15 → Xが最大 → attack
+      final detector1 = PlayerActionDetector();
+      final result1 = detector1.detect(_both(x: 1.0, y: 1.1), _ids);
+      expect(result1.type, PlayerActionType.attack);
+
+      // Y: 1.5 - 0.95 = 0.55, X: 0.8 - 0.77 = 0.03 → Yが最大 → guard
+      final detector2 = PlayerActionDetector();
+      final result2 = detector2.detect(_both(x: 0.8, y: 1.5), _ids);
+      expect(result2.type, PlayerActionType.guard);
+
+      // Z: 2.0 - 1.65 = 0.35, X: 0.78 - 0.77 = 0.01 → Zが最大 → charge
+      final detector3 = PlayerActionDetector();
+      final result3 = detector3.detect(_both(x: 0.78, z: 2.0), _ids);
+      expect(result3.type, PlayerActionType.charge);
     });
 
     test('Z軸がしきい値を超えるとchargeを検出し、チャージレベルが増加する', () {

--- a/test/widgets/outlined_text_test.dart
+++ b/test/widgets/outlined_text_test.dart
@@ -32,7 +32,7 @@ void main() {
       final outlineText = texts.firstWhere((t) => t.style?.foreground != null);
       final paint = outlineText.style!.foreground!;
       expect(paint.style, PaintingStyle.stroke);
-      expect(paint.strokeWidth, 2);
+      expect(paint.strokeWidth, 4);
       expect(paint.color.toARGB32(), const Color(0xFFF5F5F5).toARGB32());
     });
   });


### PR DESCRIPTION
close #151
close #153
close #158

- シンクロガードのダメージ軽減方式をランダム率に変更
  - 固定25ダメージ軽減から、50〜100%のランダム軽減率に変更。軽減後ダメージは四捨五入（無敵確率10%）
- 敵の攻撃1秒前に技名を予告表示
  - スケジューラー発火時に技名ラベルを表示し、1秒後に実際のダメージ・スプライト切替・SE再生を行う。ガード猶予を設けることでシンクロガードを狙いやすくした
- 加速度センサーの技発動を差分最大方式に変更
  - 複数軸が同時に閾値を超えた場合、固定優先度ではなく「値 − 閾値」の差分が最大の軸の技を発動するよう変更。誤発動の抑制に寄与
- 加速度センサーのY軸閾値を引き上げ（0.95 → 1.17）
  - 突き出し動作中に生じるY軸の副次的な動きでガードが誤発動する問題を抑制
- テスト修正